### PR TITLE
Text Field Sizing / Percentage Fix

### DIFF
--- a/psycworks/app/(main)/reports/generate/[id]/page.tsx
+++ b/psycworks/app/(main)/reports/generate/[id]/page.tsx
@@ -342,7 +342,7 @@ export default function GenerateReportPage() {
                         return result;
                       })()}
                       readOnly
-                      className="resize-none bg-white cursor-default"
+                      className="resize-none bg-white cursor-default min-h-[150px] h-auto text-base"
                       placeholder="No description available"
                     />
                   </div>

--- a/psycworks/utils/text-parser.ts
+++ b/psycworks/utils/text-parser.ts
@@ -71,9 +71,9 @@ export function parseAdvancedText(text: string, scores: AssessmentScores): strin
  * Returns a description based on percentile score
  */
 function getAverageDescription(percentile: number): string {
-  if (percentile >= 84) return "significantly above average";
-  if (percentile >= 66) return "above average";
-  if (percentile >= 35) return "average";
-  if (percentile >= 17) return "below average";
-  return "significantly below average";
+  if (percentile >= 91) return "Very High Average";
+  if (percentile >= 75) return "High Average";
+  if (percentile >= 25) return "Average";
+  if (percentile >= 9) return "Low Average";
+  return "Very Low Average";
 }


### PR DESCRIPTION
-Increased the size of the text field when generating a report to give the user a better view of their associated text.

-Some of the percentages descriptions were labeled wrong on the text parser, they are now accurate to the scores and percentages